### PR TITLE
[FEATURE] Add dev docker configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,7 @@ npm install
 
 ### Docker
 
-#### Create required docker network
-
-```console
-docker network create rangers
-```
+First [start your backend server](https://github.com/burningmantech/ranger-ims-server#development) with `docker-compose`, then start your frontend server. This will create the required docker network.
 
 #### Install dependencies
 
@@ -44,11 +40,17 @@ docker compose run --rm app npm install
 
 #### Start the frontend server
 
-First [start your backend server](https://github.com/burningmantech/ranger-ims-server#development) with `docker-compose`, then start your frontend server.
-
 ```console
 docker compose up app -d
 ```
+
+#### Troubleshooting
+
+##### Network error with all docker commands
+
+`Error response from daemon: network rangers not found`
+
+If you see this error you did not start the backend server in docker first.
 
 ### Running the Test Suite
 

--- a/README.md
+++ b/README.md
@@ -16,12 +16,38 @@ The application is implemented using [React](https://reactjs.org/).
 
 ## Development
 
-### Install dependencies
+### Without Docker
+
+#### Install dependencies
 
 You'll need to install the project's dependencies before you can run the server:
 
 ```console
 npm install
+```
+
+### Docker
+
+#### Create required docker network
+
+```console
+docker network create rangers
+```
+
+#### Install dependencies
+
+You'll need to install the project's dependencies before you can run the server:
+
+```console
+docker compose run --rm app npm install
+```
+
+#### Start the frontend server
+
+First [start your backend server](https://github.com/burningmantech/ranger-ims-server#development) with `docker-compose`, then start your frontend server.
+
+```console
+docker compose up app -d
 ```
 
 ### Running the Test Suite

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: "3.7"
+
+services:
+  app:
+    container_name: "ranger_ims_web"
+    image: "${NODE_IMG_TAG:-node:18.18.2-alpine3.17}"
+    user: ":${NODE_GROUP_ID:-1420}"
+    ports:
+      - "${NODE_PORT:-3000}:3000"
+    environment:
+      - "BACKEND_URL=${BACKEND_URL:-http://ranger_ims_server:8080}"
+    volumes:
+      - "./:/app:cached"
+    command: "npm start"
+    working_dir: "/app"
+
+networks:
+  default:
+    external: true
+    name: "${DOCKER_RANGERS_NETWORK:-rangers}"

--- a/docker-dev-sample.env
+++ b/docker-dev-sample.env
@@ -1,0 +1,3 @@
+# BACKEND_URL="http://ranger_ims_server:8080"
+# NODE_PORT=3000
+# DOCKER_RANGERS_NETWORK="rangers"

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -3,11 +3,13 @@
 
 const { createProxyMiddleware } = require("http-proxy-middleware");
 
+const backendUrl = process.env.BACKEND_URL || "http://127.0.0.1:8080"
+
 module.exports = function (app) {
   app.use(
     "/ims/api",
     createProxyMiddleware({
-      target: "http://127.0.0.1:8080",
+      target: backendUrl,
       changeOrigin: true,
     }),
   );
@@ -16,21 +18,21 @@ module.exports = function (app) {
   app.use(
     "/ims/auth",
     createProxyMiddleware({
-      target: "http://127.0.0.1:8080",
+      target: backendUrl,
       changeOrigin: true,
     }),
   );
   app.use(
     "/ims/ext",
     createProxyMiddleware({
-      target: "http://127.0.0.1:8080",
+      target: backendUrl,
       changeOrigin: true,
     }),
   );
   app.use(
     "/ims/static",
     createProxyMiddleware({
-      target: "http://127.0.0.1:8080",
+      target: backendUrl,
       changeOrigin: true,
     }),
   );


### PR DESCRIPTION
## Overview

Goal is to add docker development environment configs to support faster dev environment provisioning.

### WIP TODO

 - [ ] Organize docker files in `docker` directory
 - [ ] Add `caddy` reverse proxy with `ims.lvh.me` domain or similar
 - [ ] Fix up Dockerfile for direct `docker run` for non-compose use
 - [x] Add `README` steps for development
 - [ ] Add ability to run linters & tests from compose commands